### PR TITLE
Fix formatting and formatting settings

### DIFF
--- a/ReactiveAppKit.xcodeproj/project.pbxproj
+++ b/ReactiveAppKit.xcodeproj/project.pbxproj
@@ -55,7 +55,9 @@
 				EC9C39E61CF5A5910090F133 /* ReactiveAppKit */,
 				EC9C39E51CF5A5910090F133 /* Products */,
 			);
+			indentWidth = 2;
 			sourceTree = "<group>";
+			tabWidth = 2;
 		};
 		EC9C39E51CF5A5910090F133 /* Products */ = {
 			isa = PBXGroup;

--- a/ReactiveAppKit/ReactiveAppKit.h
+++ b/ReactiveAppKit/ReactiveAppKit.h
@@ -1,10 +1,6 @@
 //
-//  ReactiveAppKit.h
-//  ReactiveAppKit
-//
 //  Created by Srdan Rasic on 25/05/16.
 //  Copyright © 2016 ReactiveKit. All rights reserved.
-//
 
 #import <Cocoa/Cocoa.h>
 
@@ -13,7 +9,3 @@ FOUNDATION_EXPORT double ReactiveAppKitVersionNumber;
 
 //! Project version string for ReactiveAppKit.
 FOUNDATION_EXPORT const unsigned char ReactiveAppKitVersionString[];
-
-// In this header, you should import all the public headers of your framework using statements like #import <ReactiveAppKit/PublicHeader.h>
-
-

--- a/Sources/NSButton.swift
+++ b/Sources/NSButton.swift
@@ -42,4 +42,5 @@ extension NSButton {
   public var rState: Property<Int> {
     return rAssociatedPropertyForValueForKey("state")
   }
+  
 }

--- a/Sources/NSControl.swift
+++ b/Sources/NSControl.swift
@@ -25,8 +25,8 @@
 import ReactiveKit
 import Cocoa
 
-@objc class RKNSControlHelper: NSObject
-{
+@objc class RKNSControlHelper: NSObject {
+
   weak var control: NSControl?
   let pushStream = PushStream<AnyObject?>()
   
@@ -47,6 +47,7 @@ import Cocoa
     control?.action = nil
     pushStream.completed()
   }
+
 }
 
 extension NSControl {
@@ -92,4 +93,5 @@ extension NSControl {
   public var rDoubleValue: Property<Double> {
     return rAssociatedPropertyForValueForKey("doubleValue")
   }
+  
 }

--- a/Sources/NSImageView.swift
+++ b/Sources/NSImageView.swift
@@ -30,6 +30,7 @@ extension NSImageView {
   public var rImage: Property<NSImage?> {
     return rAssociatedPropertyForValueForKey("image")
   }
+  
 }
 
 extension NSImageView: BindableType {
@@ -37,4 +38,5 @@ extension NSImageView: BindableType {
   public func observer(disconnectDisposable: Disposable) -> (StreamEvent<NSImage?> -> ()) {
     return self.rImage.observer(disconnectDisposable)
   }
+
 }

--- a/Sources/NSProgressIndicator.swift
+++ b/Sources/NSProgressIndicator.swift
@@ -30,6 +30,7 @@ extension NSProgressIndicator {
   public var rProgress: Property<Float> {
     return rAssociatedPropertyForValueForKey("progress")
   }
+
 }
 
 extension NSProgressIndicator: BindableType {
@@ -37,4 +38,5 @@ extension NSProgressIndicator: BindableType {
   public func observer(disconnectDisposable: Disposable) -> (StreamEvent<Float> -> ()) {
     return self.rProgress.observer(disconnectDisposable)
   }
+
 }

--- a/Sources/NSSegmentedControl.swift
+++ b/Sources/NSSegmentedControl.swift
@@ -22,7 +22,6 @@
 //  THE SOFTWARE.
 //
 
-
 import ReactiveKit
 import Cocoa
 
@@ -35,6 +34,7 @@ extension NSSegmentedControl {
   public var rSelectedSegment: Property<Int> {
     return rAssociatedPropertyForValueForKey("selectedSegment")
   }
+  
 }
 
 extension NSSegmentedControl {
@@ -42,4 +42,5 @@ extension NSSegmentedControl {
   public func observer(disconnectDisposable: Disposable) -> (StreamEvent<Int> -> ()) {
     return self.rSelectedSegment.observer(disconnectDisposable)
   }
+
 }

--- a/Sources/NSSlider.swift
+++ b/Sources/NSSlider.swift
@@ -50,4 +50,5 @@ extension NSSlider {
   public func observer(disconnectDisposable: Disposable) -> (StreamEvent<Double> -> ()) {
     return self.rDoubleValue.observer(disconnectDisposable)
   }
+  
 }

--- a/Sources/NSTextField.swift
+++ b/Sources/NSTextField.swift
@@ -22,12 +22,11 @@
 //  THE SOFTWARE.
 //
 
-
 import ReactiveKit
 import Cocoa
 
 extension NSTextField {
-  
+
   public var rFont: Property<NSFont?> {
     return rAssociatedPropertyForValueForKey("font")
   }
@@ -55,4 +54,5 @@ extension NSTextField {
   public func observer(disconnectDisposable: Disposable) -> (StreamEvent<String> -> ()) {
     return self.rStringleValue.observer(disconnectDisposable)
   }
+  
 }

--- a/Sources/NSView.swift
+++ b/Sources/NSView.swift
@@ -34,4 +34,5 @@ extension NSView {
   public var rHidden: Property<Bool> {
     return rAssociatedPropertyForValueForKey("hidden")
   }
+  
 }


### PR DESCRIPTION
This PR sets the Xcode project indent settings to 2 spaces (as per @srdanrasic's preference). This will ensure that new contributors to the project will have their code formatted in a consistent manner. 

There are also some minor whitespace and newline changes to make the source consistent across the project.
